### PR TITLE
Amir / fix: On development mode remove 'binary-static' from the url

### DIFF
--- a/build/webpack/helpers.js
+++ b/build/webpack/helpers.js
@@ -12,8 +12,7 @@ const makeCacheGroup = (name, priority, ...matches) => ({
 });
 
 const publicPathFactory = (grunt) => () => (
-    (global.is_release || grunt.file.exists(PATHS.ROOT, 'scripts/CNAME') ? '' : '/binary-static') +
-    (global.branch ? `/${global.branch_prefix}${global.branch}` : '') +
+    (global.branch ? `/binary-static/${global.branch_prefix}${global.branch}` : '') +
     '/js/'
 );
 


### PR DESCRIPTION
We've added 'binary-static' on dev mode and in deployment on a test link. Now we should remove it from dev mode to have webtrader-chart.