### PR TITLE
fix end time input inconsistancy in different devices

### DIFF
--- a/src/javascript/_common/__tests__/string_util.js
+++ b/src/javascript/_common/__tests__/string_util.js
@@ -14,7 +14,7 @@ describe('StringUtil', () => {
         });
     });
 
-    const readable_date = '22 Jun, 2017';
+    const readable_date = '22 Jun 2017';
     const iso_date      = '2017-06-22';
     describe('.toISOFormat()', () => {
         it('works as expected', () => {

--- a/src/javascript/_common/string_util.js
+++ b/src/javascript/_common/string_util.js
@@ -1,5 +1,4 @@
 const moment     = require('moment');
-const checkInput = require('./common_functions').checkInput;
 
 const toTitleCase = str => (
     (str || '').replace(/\w[^\s/\\]*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase())
@@ -9,10 +8,7 @@ const toISOFormat = date => (date instanceof moment ? date.format('YYYY-MM-DD') 
 
 const toReadableFormat = (date) => {
     if (date instanceof moment) {
-        if (window.innerWidth < 770 && checkInput('date', 'not-a-date')) {
-            return toISOFormat(date);
-        }
-        return date.format('DD MMM, YYYY');
+        return date.format('DD MMM YYYY');
     }
     return '';
 };

--- a/src/javascript/app/components/date_picker.js
+++ b/src/javascript/app/components/date_picker.js
@@ -115,7 +115,7 @@ const DatePicker = (() => {
 
     const formatDate = (date, add) => padLeft(date + (add || 0), 2, '0');
 
-    const toDate = date => [date.getFullYear(), formatDate(date.getMonth(), 1), formatDate(date.getDate())].join('-');
+    // const toDate = date => [date.getFullYear(), formatDate(date.getMonth(), 1), formatDate(date.getDate())].join('-');
 
     const checkWidth = (selector) => {
         const $selector        = $(selector);
@@ -127,12 +127,14 @@ const DatePicker = (() => {
                 return;
             }
             if (checkInput('date', 'not-a-date') && $selector.attr('data-picker') !== 'native') {
-                hide(selector);
-                $selector.attr({ type: 'date', 'data-picker': 'native' }).val($selector.attr('data-value')).removeClass('clear');
-                if ($selector.attr('readonly')) $selector.attr('data-readonly', 'readonly').removeAttr('readonly');
-                if (date_picker_conf.minDate !== undefined) $selector.attr('min', toDate(date_picker_conf.minDate));
-                if (date_picker_conf.maxDate !== undefined) $selector.attr('max', toDate(date_picker_conf.maxDate));
-                return;
+                const value        = $selector.attr('data-value') || $selector.val();
+                const format_value = value && date_picker_conf.type !== 'diff' ? toReadableFormat(moment(value)) : $selector.val();
+                $selector.attr({ type: 'text', 'data-picker': 'jquery', 'data-value': value }).removeAttr('min max').val(format_value);
+                if ($selector.attr('data-readonly')) $selector.attr('readonly', 'readonly').removeAttr('data-readonly');
+                if ($selector.attr('data-value') && $selector.hasClass('clearable') && !$selector.attr('disabled')) {
+                    clearable($selector);
+                }
+                create(selector);
             }
         }
         if ((window.innerWidth > 769 && $selector.attr('data-picker') !== 'jquery') || (window.innerWidth < 770 && !checkInput('date', 'not-a-date'))) {

--- a/src/javascript/app/components/date_picker.js
+++ b/src/javascript/app/components/date_picker.js
@@ -115,8 +115,6 @@ const DatePicker = (() => {
 
     const formatDate = (date, add) => padLeft(date + (add || 0), 2, '0');
 
-    // const toDate = date => [date.getFullYear(), formatDate(date.getMonth(), 1), formatDate(date.getDate())].join('-');
-
     const checkWidth = (selector) => {
         const $selector        = $(selector);
         const date_picker_conf = date_pickers[selector].config_data;

--- a/src/javascript/app/components/time_picker.js
+++ b/src/javascript/app/components/time_picker.js
@@ -94,8 +94,6 @@ const TimePicker = (() => {
 
     const formatTime = time => padLeft(time, 2, '0');
 
-    const toTime = time => [formatTime(time.hour), formatTime(time.minute), '00'].join(':');
-
     const removeJqueryPicker = (selector, datepickerDate) => {
         $(selector).timepicker('destroy').removeAttr('data-picker').off('keydown keyup input');
         if (!datepickerDate) return;
@@ -122,17 +120,13 @@ const TimePicker = (() => {
 
     const updatePicker = (selector) => {
         const $selector        = $(selector);
-        const time_picker_conf = time_pickers[selector].config_data;
         if (window.innerWidth < 770 && checkInput('time', 'not-a-time') && $selector.attr('data-picker') !== 'native') {
-            removeJqueryPicker(selector);
-            $selector.attr({ type: 'time', 'data-picker': 'native' }).val($selector.attr('data-value')).removeAttr('readonly').removeClass('clear');
-
-            const minTime = time_picker_conf.minTime;
-            if (minTime) $selector.attr('min', toTime(minTime));
-
-            const maxTime = time_picker_conf.maxTime;
-            if (maxTime) $selector.attr('max', toTime(maxTime));
-            return;
+            $selector.attr({ type: 'text', 'data-picker': 'jquery', readonly: 'readonly' });
+            $selector.removeAttr('min max');
+            if ($selector.attr('data-value') && $selector.hasClass('clearable') && !$selector.attr('disabled')) {
+                clearable($selector);
+            }
+            addJqueryPicker(selector);
         }
         if ((window.innerWidth > 769 && $selector.attr('data-picker') !== 'jquery') || (window.innerWidth < 770 && !checkInput('time', 'not-a-time'))) {
             $selector.attr({ type: 'text', 'data-picker': 'jquery', readonly: 'readonly' });


### PR DESCRIPTION
![Screenshot from 2021-08-23 18-49-34](https://user-images.githubusercontent.com/82078941/130463900-955e018b-f373-4d28-a6a1-e2bec0af4b2a.png)
![Screenshot from 2021-08-23 18-50-26](https://user-images.githubusercontent.com/82078941/130464266-41e24569-48d6-43b3-b4d1-84868bfdb798.png)
![Screenshot from 2021-08-23 18-53-41](https://user-images.githubusercontent.com/82078941/130464287-75f14cc2-2052-4e0b-a064-48e5484a2efb.png)
