### PR TITLE
Use context instead repository defined environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ workflows:
           filters:
             branches:
               only: /^master$/
+          context: binary-frontend-artifact-upload
       - release_production:
           filters:
             branches:
@@ -268,3 +269,4 @@ workflows:
               ignore: /.*/
             tags:
               only: /^production.*/
+          context: binary-frontend-artifact-upload


### PR DESCRIPTION
# Changes
- Use context (project) instead of repository defined variables

@balakrishna-binary 