### PR TITLE
Cloudflare pages: Fix nasty redirection and regex.

### DIFF
--- a/src/javascript/app/base/binary_loader.js
+++ b/src/javascript/app/base/binary_loader.js
@@ -25,10 +25,6 @@ const BinaryLoader = (() => {
     let active_script = null;
 
     const init = () => {
-        if (!/\.html$/i.test(window.location.pathname)) {
-            window.location.pathname += '.html';
-            return;
-        }
 
         if (!isStorageSupported(localStorage) || !isStorageSupported(sessionStorage)) {
             Header.displayNotification({ key: 'storage_not_supported', title: 'Storage not supported', message: localize('Requires your browser\'s web storage to be enabled in order to function properly. Please enable it or exit private browsing mode.'), type: 'danger' });

--- a/src/javascript/app/base/binary_pjax.js
+++ b/src/javascript/app/base/binary_pjax.js
@@ -36,7 +36,7 @@ const BinaryPjax = (() => {
         // put current content to cache, so we won't need to load it again
         if (content) {
             window.history.replaceState({ url }, title, url);
-            setDataPage(content, url);
+            setDataPage(content, window.location.pathname);
             params.container.dispatchEvent(new CustomEvent('binarypjax:after', { detail: content }));
         }
 
@@ -50,8 +50,10 @@ const BinaryPjax = (() => {
         }
     };
 
-    const setDataPage = (content, url) => {
-        content.setAttribute('data-page', url.match(/.+\/(.+)\.html.*/)[1]);
+    const setDataPage = (content, pathname) => {
+        const filename = pathname.substr(pathname.lastIndexOf('/') + 1);
+        const page = filename.replace(/\.[^/.]+$/, '');
+        content.setAttribute('data-page', page);
     };
 
     const handleClick = (event) => {
@@ -143,7 +145,7 @@ const BinaryPjax = (() => {
                 return;
             }
 
-            setDataPage(result.content, url);
+            setDataPage(result.content, window.location.pathname);
             cachePut(url, result);
             replaceContent(url, result, replace);
         };


### PR DESCRIPTION
# Changes
- We are hosting backups on Cloudflare pages. Cloudflare pages webserver is rewriting URLs to remove `.html` extensions while still flexibly serving the html file hence has a very little impact in general. Forcing `.html` suffix is producing an infinite loop. And this feature seems not needed in general for routing/redirect logic, just a convenience.

We did a QA of a derived version of this PR via URL: [test.cf-pages-binary-static.deriv.com](http://test.cf-pages-binary-static.deriv.com/)