### PR TITLE
Cloudflare pages: Align regex on binary-static

### DIFF
--- a/src/javascript/app/base/binary_pjax.js
+++ b/src/javascript/app/base/binary_pjax.js
@@ -51,9 +51,10 @@ const BinaryPjax = (() => {
     };
 
     const setDataPage = (content, pathname) => {
-        const filename = pathname.substr(pathname.lastIndexOf('/') + 1);
-        const page = filename.replace(/\.[^/.]+$/, '');
-        content.setAttribute('data-page', page);
+        let filename = pathname.match(/.+\/(.+)/)[1]; // get path
+        filename = filename.replace(/\?.+$/, ''); // remove parameters if any
+        filename = filename.replace(/\.[^/.]+$/, ''); // remove suffix if any
+        content.setAttribute('data-page', filename);
     };
 
     const handleClick = (event) => {


### PR DESCRIPTION
# Changes
- There is no reported issue with previous code but this pull request brings some more "robust" logic (in particular remove query parameters before removing suffix because query string that can contain a dot)