### PR TITLE
Matin/77628/remove all links tech.binary.com

### DIFF
--- a/src/javascript/_common/url.js
+++ b/src/javascript/_common/url.js
@@ -67,7 +67,6 @@ const Url = (() => {
         'bot.binary.com'       : 'www.binary.bot',
         'developers.binary.com': 'developers.binary.com', // same, shouldn't change
         'academy.binary.com'   : 'academy.binary.com',
-        'tech.binary.com'      : 'tech.binary.com',
         'blog.binary.com'      : 'blog.binary.com',
     };
 

--- a/src/templates/static/about/careers.jsx
+++ b/src/templates/static/about/careers.jsx
@@ -170,14 +170,6 @@ const Careers = () => {
                     <Box
                         gr='gr-3 gr-6-p'
                         padding='20'
-                        icon='images/pages/careers/tb-icon.svg'
-                        href='https://tech.binary.com'
-                        text={it.L('Read the [_1] tech blog', it.website_name)}
-                        target='_blank'
-                    />
-                    <Box
-                        gr='gr-3 gr-6-p'
-                        padding='20'
                         icon='images/pages/careers/bb-icon.svg'
                         href='https://blog.binary.com'
                         text={it.L('Read the [_1] company blog', it.website_name)}

--- a/src/templates/static/about/job_details.jsx
+++ b/src/templates/static/about/job_details.jsx
@@ -382,8 +382,6 @@ const JobDetails = () => (
 
                             <p>{it.L('[_1]\'s IT team is responsible for the design, development, and operation of our high-traffic web applications. As our Security Researcher, we expect you to stay informed about the latest security bulletins and findings, and actively monitor our software development pipeline to find and raise potential security issues.', it.website_name)}</p>
 
-                            <p>{it.L('As a strong proponent of open source, we encourage publication of findings, methods, and tools via GitHub and our technical blog at [_1] You will also assist our developers in understanding and patching the bugs that you find.', '<a href=\'https://tech.binary.com/\' target=\'_blank\'>https://tech.binary.com/</a>')}</p>
-
                             <p>{it.L('You will also encourage security awareness throughout the organisation via regular communication on security best practices and the latest online threats.')}</p>
 
                             <UlText


### PR DESCRIPTION
- To remove all the links to tech.binary.com because it got deprecated in favour of tech.deriv.com