### PR TITLE
Added Tether TRC20 name in the currency lists

### DIFF
--- a/src/javascript/_common/base/currency_base.js
+++ b/src/javascript/_common/base/currency_base.js
@@ -13,6 +13,7 @@ const displayed_currencies = {
     ETH  : localize('Ethereum'),
     USDT : localize('Tether Omni'),
     eUSDT: localize('Tether ERC20'),
+    tUSDT: localize('Tether TRC20'),
     USDC : localize('USD Coin'),
     LTC  : localize('Litecoin'),
 };


### PR DESCRIPTION
Changes:

-   tUSDT currency display name is missing from the account switcher list and it defaults to "Real" which is being fixed in this PR and now it is displaying "Tether TRC20"



## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

