### PR TITLE
ci: update node version

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: 12.22
+        node-version: 14
     - name: Install dependencies
       uses: "./.github/actions/npm_install"
     - name: Build
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 14
     - name: Download Artifacts
       uses: actions/download-artifact@v3.0.2
       with:
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 14
       - name: Conclusion
         uses: technote-space/workflow-conclusion-action@v3
       - uses: actions/download-artifact@v3.0.2

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: 12.22
+        node-version: 14
     - name: Install dependencies
       uses: "./.github/actions/npm_install"
     - name: Build Staging
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 14
     - uses: actions/download-artifact@v3.0.2
       with:
         path: dist


### PR DESCRIPTION
Changes:

Used Node version 14 for all of the actions in both production and staging worklfow.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

