### PR TITLE
ci: use npx to install to refrain installing package on the app

### DIFF
--- a/.github/actions/publish_to_pages_production/action.yml
+++ b/.github/actions/publish_to_pages_production/action.yml
@@ -12,7 +12,6 @@ runs:
   steps:
   - name: Publish to cloudflare pages (production)
     run: |-
-      npm i wrangler@3.1.0
       cd dist
       npx wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=main
       echo "New website - http://cf-pages-deriv-binary-static.deriv.com"

--- a/.github/actions/publish_to_pages_production/action.yml
+++ b/.github/actions/publish_to_pages_production/action.yml
@@ -13,6 +13,6 @@ runs:
   - name: Publish to cloudflare pages (production)
     run: |-
       cd dist
-      npx wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=main
+      npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=main
       echo "New website - http://cf-pages-deriv-binary-static.deriv.com"
     shell: bash

--- a/.github/actions/publish_to_pages_staging/action.yml
+++ b/.github/actions/publish_to_pages_staging/action.yml
@@ -13,6 +13,6 @@ runs:
   - name: Publish to cloudflare pages (staging)
     run: |-
       cd dist
-      npx wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=staging
+      npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=staging
       echo "New staging website - http://staging.cf-pages-deriv-binary-static.deriv.com"
     shell: bash

--- a/.github/actions/publish_to_pages_staging/action.yml
+++ b/.github/actions/publish_to_pages_staging/action.yml
@@ -12,7 +12,6 @@ runs:
   steps:
   - name: Publish to cloudflare pages (staging)
     run: |-
-      npm i wrangler@3.1.0
       cd dist
       npx wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=staging
       echo "New staging website - http://staging.cf-pages-deriv-binary-static.deriv.com"


### PR DESCRIPTION
Changes:

Use NPX installation directly instead of installing on the app.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

