### PR TITLE
Ako/ Turn inputs to env variables

### DIFF
--- a/.github/actions/publish_to_pages_production/action.yml
+++ b/.github/actions/publish_to_pages_production/action.yml
@@ -11,6 +11,9 @@ runs:
   using: composite
   steps:
   - name: Publish to cloudflare pages (production)
+    env:
+    CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+    CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
     run: |-
       cd dist
       npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=main

--- a/.github/actions/publish_to_pages_production/action.yml
+++ b/.github/actions/publish_to_pages_production/action.yml
@@ -12,8 +12,8 @@ runs:
   steps:
   - name: Publish to cloudflare pages (production)
     env:
-    CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
-    CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
     run: |-
       cd dist
       npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=main

--- a/.github/actions/publish_to_pages_staging/action.yml
+++ b/.github/actions/publish_to_pages_staging/action.yml
@@ -12,8 +12,8 @@ runs:
   steps:
   - name: Publish to cloudflare pages (staging)
     env:
-    CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
-    CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
     run: |-
       cd dist
       npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=staging

--- a/.github/actions/publish_to_pages_staging/action.yml
+++ b/.github/actions/publish_to_pages_staging/action.yml
@@ -11,6 +11,9 @@ runs:
   using: composite
   steps:
   - name: Publish to cloudflare pages (staging)
+    env:
+    CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+    CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
     run: |-
       cd dist
       npx -y wrangler pages deploy . --project-name=deriv-binary-static-pages --branch=staging


### PR DESCRIPTION
Changes:
This is to use action inputs as env variables for the wrangler.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

