### PR TITLE
Nijil / Updated action/upload-artifact and action/download-artifact to v4

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Run Tests"
         run: npm run test
       - name: Upload Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: dist
           path: dist
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: 20
       - name: Download Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: dist
           path: dist
@@ -94,7 +94,7 @@ jobs:
       - name: Conclusion
         uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
       - name: Download Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: dist
           path: dist

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -37,7 +37,7 @@ jobs:
           target_branch: staging
       - name: "Run Tests"
         run: npm run test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: dist
           path: dist
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
         with:
           node-version: 20
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Changes:

-   Release of SmartTrader failed because `action/upload-artifact` and `action/download-artifact` v3 is deprecated now. Updated them to v4.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [x] Dependency update
-   [ ] Documentation update
-   [ ] Release

