### PR TITLE
fix: remove the storing of active_login id while account switching

### DIFF
--- a/src/javascript/app/base/page.js
+++ b/src/javascript/app/base/page.js
@@ -60,18 +60,10 @@ const Page = (() => {
             // Find matching account based on account type
             if (session_account === 'demo') {
                 active_loginid = Object.keys(new_accounts).find(loginid => /^VR/.test(loginid));
-                if (active_loginid) {
-                    SessionStore.set('active_loginid', active_loginid);
-                    LocalStore.set('active_loginid', active_loginid);
-                }
             } else {
                 active_loginid = Object.keys(new_accounts).find(loginid =>
                     new_accounts[loginid].currency?.toUpperCase() === session_account.toUpperCase()
                 );
-                if (active_loginid) {
-                    SessionStore.set('active_loginid', active_loginid);
-                    LocalStore.set('active_loginid', active_loginid);
-                }
             }
         }
 


### PR DESCRIPTION
Changes:

-   remove the storing of active_login id while account switching

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

