### PR TITLE
Adrienne / Update cache action

### DIFF
--- a/.github/actions/npm_install/action.yml
+++ b/.github/actions/npm_install/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: restore_cache
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+      uses: actions/cache@v4
       with:
         key: node-{{ checksum "package-lock.json" }}
         path: UPDATE_ME
@@ -15,7 +15,7 @@ runs:
       run: npm ci
       shell: bash
     - name: save_cache
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: node-{{ checksum "package-lock.json" }}


### PR DESCRIPTION
Changes:
-  Githubs Actions cache is deprecated for V3, updating it to V4 to allow for test links to build

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

