### PR TITLE
GRWT-5491 / Kate / Add Modal and try catch around login and logout of oidc

### DIFF
--- a/src/javascript/app/base/client.js
+++ b/src/javascript/app/base/client.js
@@ -89,11 +89,16 @@ const Client = (() => {
         if (show_login_page) {
             sessionStorage.setItem('showLoginPage', 1);
         }
-        BinarySocket.send({ logout: '1', passthrough: { redirect_to } }).then((response) => {
-            if (response.logout === 1) {
-                GTM.pushDataLayer({ event: 'log_out' });
-            }
-        });
+        try {
+            BinarySocket.send({ logout: '1', passthrough: { redirect_to } }).then((response) => {
+                if (response.logout === 1) {
+                    GTM.pushDataLayer({ event: 'log_out' });
+                }
+            });
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+        }
     };
 
     const redirection = (response) => {

--- a/src/javascript/app/base/header.js
+++ b/src/javascript/app/base/header.js
@@ -30,6 +30,7 @@ const { default: isHubEnabledCountry } = require('../common/isHubEnabledCountry.
 const { SessionStore } = require('../../_common/storage');
 const Chat                     = require('../../_common/chat.js').default;
 const getRemoteConfig          = require('../hooks/useRemoteConfig').getRemoteConfig;
+const ErrorModal = require('../../../templates/_common/components/error-modal.jsx').default;
 
 const header_icon_base_path = '/images/pages/header/';
 const wallet_header_icon_base_path = '/images/pages/header/wallets/';
@@ -680,12 +681,24 @@ const Header = (() => {
             const redirectCallbackUri = `${window.location.origin}/${currentLanguage}/callback`;
             const postLoginRedirectUri = window.location.origin;
             const postLogoutRedirectUri = `${window.location.origin}/${currentLanguage}/trading`;
-            // Test commit
-            await requestOidcAuthentication({
-                redirectCallbackUri,
-                postLoginRedirectUri,
-                postLogoutRedirectUri,
-            });
+            try {
+                await requestOidcAuthentication({
+                    redirectCallbackUri,
+                    postLoginRedirectUri,
+                    postLogoutRedirectUri,
+                });
+            } catch (error){
+                ErrorModal.init({
+                    message      : localize('Something went wrong while logging in. Please refresh and try again.'),
+                    buttonText   : localize('Refresh'),
+                    onButtonClick: () => {
+                        ErrorModal.remove();
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 0);
+                    },
+                });
+            }
         } else {
             Login.redirectToLogin();
         }

--- a/src/sass/_common/components.scss
+++ b/src/sass/_common/components.scss
@@ -441,3 +441,20 @@
         }
     }
 }
+
+.error_modal_container {
+    @media only screen and (min-width: 769px) {
+        .quill-button {
+            &__full-width {
+                width: auto !important;
+                align-self: flex-end !important;
+            }
+        }
+    }
+
+    .quill-modal__background {
+        @media only screen and (max-width: 768px) {
+           padding: 20px;
+        }
+    }
+}

--- a/src/templates/_common/components/error-modal.jsx
+++ b/src/templates/_common/components/error-modal.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { Modal } from '@deriv-com/quill-ui';
+
+const ErrorModal = ({ message, buttonText, onButtonClick }) => {
+    const [isOpened, setIsOpened] = React.useState(true);
+    
+    return (
+        <Modal
+            isOpened={isOpened}
+            toggleModal={()=>setIsOpened(!isOpened)}
+            showCrossIcon={false}
+            buttonColor='coral'
+            primaryButtonCallback={onButtonClick}
+            primaryButtonLabel={buttonText}
+            width='sm'
+            portalId='error_modal_container'
+        >
+            <Modal.Body>{message}</Modal.Body>
+        </Modal>
+    );
+};
+
+ErrorModal.propTypes = {
+    buttonText   : PropTypes.string.isRequired,
+    message      : PropTypes.string.isRequired,
+    onButtonClick: PropTypes.func.isRequired,
+};
+
+const ErrorModalModule = (() => {
+    let container = null;
+
+    const init = (props) => {
+        // Clean up any existing modal first
+        if (container) {
+            remove();
+        }
+
+        container = document.createElement('div');
+        container.id = 'error_modal_container';
+        container.className = 'error_modal_container';
+        document.body.appendChild(container);
+        
+        ReactDOM.render(<ErrorModal {...props} />, container);
+    };
+
+    const remove = () => {
+        if (container) {
+            ReactDOM.unmountComponentAtNode(container);
+            container.remove();
+            container = null;
+        }
+    };
+
+    return {
+        init,
+        remove,
+    };
+})();
+
+export default ErrorModalModule;


### PR DESCRIPTION
Changes:

-   Authentication Error Handling: added try-catch blocks around login/logout operations in header.js, auth.js and client.js. 
-   Reused modal from quill-ui  for error reflection. 
-   Changed requestOidcAuthentication in auth.js

<img width="1370" alt="Screenshot 2025-03-31 at 1 21 05 PM" src="https://github.com/user-attachments/assets/5c4f56f2-e7e9-4c0c-a6fe-7d8982317171" />
<img width="448" alt="Screenshot 2025-03-31 at 1 23 42 PM" src="https://github.com/user-attachments/assets/285279ab-e6db-4fd6-ab0c-3a5ab57b97cf" />


## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

