### PR TITLE
TRAH-6008 / Kate / [OIDC] Partner account hangs in Smart Trader

### DIFF
--- a/src/javascript/_common/analytics.js
+++ b/src/javascript/_common/analytics.js
@@ -3,6 +3,7 @@ const CountryUtils = require('@deriv-com/utils').CountryUtils;
 const Cookies = require('js-cookie');
 const { SessionStore, LocalStore } = require('./storage');
 const Language = require('./language');
+const { tryParseJSON } = require('./utility');
 const { getAppId } = require('../config');
 
 const Analytics = (() => {
@@ -10,7 +11,8 @@ const Analytics = (() => {
         const loginid = SessionStore?.get('active_loginid') || LocalStore?.get('active_loginid');
         const active_account = loginid && JSON.parse(localStorage.getItem('client.accounts') || '{}')[loginid];
         const utmData = Cookies.get('utm_data');
-        const ppcCampaignCookies = utmData ? JSON.parse(utmData) : {
+        const parsedUtmData = utmData ? tryParseJSON(utmData) : { success: false };
+        const ppcCampaignCookies = parsedUtmData.success ? parsedUtmData.data : {
             utm_campaign: 'no campaign',
             utm_content : 'no content',
             utm_medium  : 'no medium',

--- a/src/javascript/_common/utility.js
+++ b/src/javascript/_common/utility.js
@@ -289,6 +289,19 @@ class PromiseClass {
 const lc_licenseID = 12049137;
 const lc_clientID = '66aa088aad5a414484c1fd1fa8a5ace7';
 
+/**
+ * Safely tries to parse a JSON string
+ * @param {string} str - The string to parse
+ * @returns {Object} Object with success status and parsed data
+ */
+const tryParseJSON = (str) => {
+    try {
+        return { success: true, data: JSON.parse(str) };
+    } catch (e) {
+        return { success: false, data: null };
+    }
+};
+
 module.exports = {
     showLoadingImage,
     getHighestZIndex,
@@ -312,6 +325,7 @@ module.exports = {
     removeObjProperties,
     getTopLevelDomain,
     getHostname,
+    tryParseJSON,
     lc_licenseID,
     lc_clientID,
 };


### PR DESCRIPTION
Changes:

-  Based on the error message in the browser console, it appears that the provided data was in an incorrect format, which caused JSON.parse() to throw an exception. To improve resilience, a utility function has been added for safe JSON parsing. If parsing fails due to malformed input, the function logs a warning and gracefully falls back to a default value instead of breaking the application.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

