### PR TITLE
Potential fix for code scanning alert no. 84: Client-side URL redirect

### DIFF
--- a/src/javascript/app/pages/callback/callback.jsx
+++ b/src/javascript/app/pages/callback/callback.jsx
@@ -85,17 +85,27 @@ const CallbackContainer = () => {
             // redirect back
             let set_default = true;
             if (redirect_url) {
-                const do_not_redirect = [
-                    'reset_passwordws',
-                    'lost_passwordws',
-                    'change_passwordws',
-                    'home',
-                    '404',
-                ];
-                const reg = new RegExp(do_not_redirect.join('|'), 'i');
-                if (!reg.test(redirect_url) && urlFor('') !== redirect_url) {
-                    set_default = false;
-                }
+                const allowed_domains = ['example.com', 'deriv.com']; // Add trusted domains here
+                const url_object = new URL(redirect_url, window.location.origin);
+                const is_trusted_domain = allowed_domains.some(domain => url_object.hostname.endsWith(domain));
+
+                if (!is_trusted_domain) {
+                    redirect_url = null; // Invalidate the redirect URL if not trusted
+                } else {
+                    const do_not_redirect = [
+                        'reset_passwordws',
+                        'lost_passwordws',
+                        'change_passwordws',
+                        'home',
+                       '404',
+                   ];
+                   const reg = new RegExp(do_not_redirect.join('|'), 'i');
+                   if (reg.test(redirect_url) || urlFor('') === redirect_url) {
+                       redirect_url = null; // Invalidate if it matches disallowed paths
+                   } else {
+                       set_default = false;
+                   }
+               }
             }
             if (set_default) {
                 const lang_cookie = urlLang(redirect_url) || Cookies.get('language');


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/smarttrader/security/code-scanning/84](https://github.com/deriv-com/smarttrader/security/code-scanning/84)

To fix the issue, we need to ensure that the `redirect_url` is validated against a whitelist of trusted domains or paths before it is used in `window.location.replace`. This can be achieved by:
1. Maintaining a list of allowed URLs or domains on the client side.
2. Validating the `redirect_url` against this list before performing the redirection.
3. Falling back to a default URL if the `redirect_url` is not valid.

The changes will be made in `src/javascript/app/pages/callback/callback.jsx` to include a robust validation mechanism for `redirect_url`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
