### PR TITLE
Farabi/fix--remove-client-info-cookie

### DIFF
--- a/src/javascript/app/base/client.js
+++ b/src/javascript/app/base/client.js
@@ -89,6 +89,8 @@ const Client = (() => {
         if (show_login_page) {
             sessionStorage.setItem('showLoginPage', 1);
         }
+        // Remove client_information cookie
+        removeCookies('client_information');
         try {
             BinarySocket.send({ logout: '1', passthrough: { redirect_to } }).then((response) => {
                 if (response.logout === 1) {
@@ -141,7 +143,7 @@ const Client = (() => {
 
         if (response.logout !== 1) return;
         removeCookies('login', 'loginid', 'loginid_list', 'email', 'residence', 'settings'); // backward compatibility
-        removeCookies('reality_check', 'affiliate_token', 'affiliate_tracking', 'onfido_token','utm_data', 'gclid', 'client_information');
+        removeCookies('reality_check', 'affiliate_token', 'affiliate_tracking', 'onfido_token','utm_data', 'gclid');
         // clear elev.io session storage
         sessionStorage.removeItem('_elevaddon-6app');
         sessionStorage.removeItem('_elevaddon-6create');


### PR DESCRIPTION
This pull request includes changes to the `src/javascript/app/base/client.js` file to improve cookie management during the logout process. The most important changes involve removing the `client_information` cookie and ensuring backward compatibility by adjusting the list of cookies cleared during logout.

### Cookie Management Improvements:

* [`src/javascript/app/base/client.js`](diffhunk://#diff-67c24eaf20a261c5e524eccd6c7f1eb9e16aeb74a58e7ae580b3a5a9e3e933ffR92-R93): Added code to explicitly remove the `client_information` cookie during the logout process.
* [`src/javascript/app/base/client.js`](diffhunk://#diff-67c24eaf20a261c5e524eccd6c7f1eb9e16aeb74a58e7ae580b3a5a9e3e933ffL144-R146): Updated the list of cookies cleared during logout for backward compatibility by removing `client_information` from the list.