### PR TITLE
Potential fix for code scanning alert no. 83: Client-side URL redirect

### DIFF
--- a/src/javascript/app/pages/callback/callback.jsx
+++ b/src/javascript/app/pages/callback/callback.jsx
@@ -84,36 +84,33 @@ const CallbackContainer = () => {
 
             // redirect back
             let set_default = true;
-            if (redirect_url) {
-                const do_not_redirect = [
-                    'reset_passwordws',
-                    'lost_passwordws',
-                    'change_passwordws',
-                    'home',
-                    '404',
-                ];
-                const reg = new RegExp(do_not_redirect.join('|'), 'i');
-                if (!reg.test(redirect_url) && urlFor('') !== redirect_url) {
-                    set_default = false;
-                }
+            const trusted_urls = [
+                urlFor('user/metatrader'),
+                Client.defaultRedirectUrl(),
+                urlFor('home'),
+            ];
+
+            if (redirect_url && trusted_urls.includes(redirect_url)) {
+                set_default = false;
             }
+
             if (set_default) {
-                const lang_cookie = urlLang(redirect_url) || Cookies.get('language');
+                const lang_cookie = Cookies.get('language') || getLanguage();
                 const language = getLanguage();
-                redirect_url =
-                    Client.isAccountOfType('financial') || Client.isOptionsBlocked()
-                        ? urlFor('user/metatrader')
-                        : Client.defaultRedirectUrl();
-                if (lang_cookie && lang_cookie !== language) {
-                    redirect_url = redirect_url.replace(
-                        new RegExp(`/${language}/`, 'i'),
-                        `/${lang_cookie.toLowerCase()}/`
-                    );
-                }
-            }
-            getElementById('loading_link').setAttribute('href', redirect_url);
-            
-            window.location.replace(redirect_url); // need to redirect not using pjax
+               redirect_url =
+                   Client.isAccountOfType('financial') || Client.isOptionsBlocked()
+                       ? urlFor('user/metatrader')
+                       : Client.defaultRedirectUrl();
+               if (lang_cookie && lang_cookie !== language) {
+                   redirect_url = redirect_url.replace(
+                       new RegExp(`/${language}/`, 'i'),
+                       `/${lang_cookie.toLowerCase()}/`
+                   );
+               }
+           }
+           getElementById('loading_link').setAttribute('href', redirect_url);
+           
+           window.location.replace(redirect_url); // need to redirect not using pjax
         });
     };
 


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/smarttrader/security/code-scanning/83](https://github.com/deriv-com/smarttrader/security/code-scanning/83)

To fix the issue, we need to ensure that the `redirect_url` is validated against a whitelist of trusted domains or paths before redirection. This can be achieved by maintaining a list of authorized URLs on the server or in the client code and checking the `redirect_url` against this list. If the `redirect_url` is not in the whitelist, the code should default to a safe URL.

**Steps to fix:**
1. Introduce a whitelist of trusted URLs or domains in the client code.
2. Validate the `redirect_url` against this whitelist before using it in `window.location.replace`.
3. If the `redirect_url` is not in the whitelist, set it to a default safe URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
