### PR TITLE
Farabi/grwt-5822/fix-inconsistent-header

### DIFF
--- a/src/sass/_common/header.scss
+++ b/src/sass/_common/header.scss
@@ -186,7 +186,7 @@ body .header, .wallet__header {
         background: var(--general-section-2);
         height: 30px;
         width: 1px;
-        margin-left: 8px;
+        margin-left: 4px;
     }
     .is-login, .is-logout {
         display: none;
@@ -238,7 +238,11 @@ body .header, .wallet__header {
                 text-decoration: none;
                 letter-spacing: 0;
                 text-transform: capitalize;
-                padding: 0 8px;
+                padding: 0 16px;
+                
+                &.url-appstore {
+                    padding: 0 10px 0 16px;
+                }
                 word-wrap: break-word;
             }
             &-item {
@@ -352,6 +356,7 @@ body .header, .wallet__header {
     }
     &__expand {
         transition: transform 500ms;
+        margin: 0 8px;
 
         &-light {
             transition: transform 500ms;
@@ -363,7 +368,7 @@ body .header, .wallet__header {
     }
     &__notification {
         height: min-content;
-        margin-right: 10px;
+        margin: 0 10px;
         position: relative;
 
         &-icon {

--- a/src/sass/_common/header.scss
+++ b/src/sass/_common/header.scss
@@ -291,6 +291,9 @@ body .header, .wallet__header {
             align-items: center;
             height: 100%;
             padding: 0 16px;
+            @media (min-width: 320px) and (max-width: 767px) {
+            padding: 0;
+        }
             cursor: pointer;
             gap: 8px;
 
@@ -347,7 +350,7 @@ body .header, .wallet__header {
         }
     }
     &__deposit {
-        margin: 0 16px 0 8px;
+        margin: 0 8px;
     }
     &__divider {
         height: 32px;
@@ -370,6 +373,10 @@ body .header, .wallet__header {
         height: min-content;
         margin: 0 10px;
         position: relative;
+        
+        @media (min-width: 320px) and (max-width: 767px) {
+            margin: 0;
+        }
 
         &-icon {
             width: 25px;

--- a/src/templates/_common/_layout/header.jsx
+++ b/src/templates/_common/_layout/header.jsx
@@ -13,7 +13,7 @@ const Header = () => (
                 <span className='header__hamburger--container'>
                     <img id='header__hamburger' className='header__hamburger mobile-show' />
                 </span>
-                <div className='header-menu-item header-menu-links client_logged_in invisible mobile-hide'>
+                <div className='header-menu-item header-menu-links client_logged_in invisible'>
                     <a className='url-deriv-com' target='_blank' rel='noopener noreferrer' href='https://deriv.com'>
                         <img className='deriv-com-logo' />
                     </a>
@@ -28,7 +28,21 @@ const Header = () => (
                     <a className='url-appstore header__menu-links-item'>
                         <span className='header__menu-item--label'>
                             <img id='appstore-icon' className='header__icon-text appstore-icon' />
-                            {it.L('Trader\'s hub')}
+                            {it.L('Trader\'s Hub')}
+                        </span>
+                    </a>
+                </div>
+                <div className='header__menu-item header__menu-links client_logged_in invisible mobile-hide'>
+                    <a className='url-cashier-deposit header__menu-links-item'>
+                        <span className='header__menu-item--label'>
+                            <img id='cashier-icon' className='header__icon-text' />
+                            {it.L('Cashier')}
+                        </span>
+                    </a>
+                    <a className='url-reports-positions header__menu-links-item'>
+                        <span className='header__menu-item--label'>
+                            <img className='header__icon-text reports-icon' />
+                            {it.L('Reports')}
                         </span>
                     </a>
                 </div>
@@ -36,26 +50,9 @@ const Header = () => (
                     <img className='header__logo' />
                     <img id='platform__switcher-expand' className='header__icon header__expand' />
                 </div>
-                <div className='header__menu-item header__menu-links client_logged_in invisible mobile-hide'>
-                    <a className='url-reports-positions header__menu-links-item'>
-                        <span className='header__menu-item--label'>
-                            <img className='header__icon-text reports-icon' />
-                            {it.L('Reports')}
-                        </span>
-                    </a>
-                    <a className='url-cashier-deposit header__menu-links-item'>
-                        <span className='header__menu-item--label'>
-                            <img id='cashier-icon' className='header__icon-text' />
-                            {it.L('Cashier')}
-                        </span>
-                    </a>
-                </div>
             </div>
             <div className='header__menu-right client_logged_in invisible'>
-                <Notification />
-                <a className='url-account-details header__account header__menu-item mobile-hide'>
-                    <img className='header__icon-button' id='header__account-settings' />
-                </a>
+                <a className='url-cashier-deposit btn btn--primary header__deposit mobile-hide'>{it.L('Deposit')}</a>
                 <div className='header__divider mobile-hide' />
                 <div className='header__menu-item header__menu-acc' id='acc_switcher'>
                     <div className='header__acc-info'>
@@ -149,7 +146,11 @@ const Header = () => (
                         </div>
                     </div>
                 </div>
-                <a className='url-cashier-deposit btn btn--primary header__deposit mobile-hide'>{it.L('Deposit')}</a>
+                <div className='header__divider' />
+                <Notification />
+                <a className='url-account-details header__account header__menu-item mobile-hide'>
+                    <img className='header__icon-button' id='header__account-settings' />
+                </a>
             </div>
             <div className='header__menu-right is-logout'>
                 <div className='header__btn'>

--- a/src/templates/_common/_layout/wallet-header.jsx
+++ b/src/templates/_common/_layout/wallet-header.jsx
@@ -13,24 +13,20 @@ const WalletHeader = () => (
                 <span className='wallet__header__hamburger--container'>
                     <img id='header__hamburger' className='header__hamburger mobile-show' />
                 </span>
-                <div className='wallet__header-menu-item wallet__header-menu-links is-logout'>
+                <div className='wallet__header-menu-item wallet__header-menu-links'>
                     <a className='url-deriv-com' target='_blank' rel='noopener noreferrer' href='https://deriv.com'>
                         <img className='deriv-com-logo' />
                     </a>
                 </div>
                 <div id='wallet-divider' className='wallet__header-divider mobile-hide-wallet' />
+                <div className='wallet__header-divider client_logged_in invisible mobile-hide' />
                 <div className='header__menu-item header__menu-links mobile-hide'>
                     <a className='url-appstore header__menu-links-item'>
                         <span className='header__menu-item--label'>
                             <img id='appstore-icon' className='header__icon-text appstore-icon' />
-                            {it.L('Trader\'s hub')}
+                            {it.L('Trader\'s Hub')}
                         </span>
                     </a>
-                </div>
-                <div className='wallet__header-divider client_logged_in invisible mobile-hide' />
-                <div id='platform__switcher' className='header__menu-item platform__switcher mobile-hide'>
-                    <img className='header__logo' />
-                    <img id='platform__switcher-expand' className='header__icon header__expand' />
                 </div>
                 <div className='header__menu-links client_logged_in invisible mobile-hide'>
                     <a className='url-reports-positions header__menu-links-item'>
@@ -40,12 +36,13 @@ const WalletHeader = () => (
                         </span>
                     </a>
                 </div>
+                <div id='platform__switcher' className='header__menu-item platform__switcher mobile-hide'>
+                    <img className='header__logo' />
+                    <img id='platform__switcher-expand' className='header__icon header__expand' />
+                </div>
             </div>
             <div id='wallet__header-menu-right' className='wallet__header-menu-right client_logged_in invisible'>
-                <Notification />
-                <a className='url-account-details header__account header__menu-item mobile-hide'>
-                    <img className='header__icon-button' id='header__account-settings' />
-                </a>
+                <a className='url-wallets-deposit btn btn--primary header__deposit mobile-hide'>{it.L('Manage funds')}</a>
                 <div className='header__divider mobile-hide' />
                 <div className='header__menu-item header__menu-acc' id='wallet_switcher'>
                     <div className='header__acc-info'>
@@ -86,7 +83,11 @@ const WalletHeader = () => (
                         </div>
                     </div>
                 </div>
-                <a className='url-wallets-deposit btn btn--primary header__deposit mobile-hide'>{it.L('Manage funds')}</a>
+                <div className='header__divider' />
+                <Notification />
+                <a className='url-account-details header__account header__menu-item mobile-hide'>
+                    <img className='header__icon-button' id='header__account-settings' />
+                </a>
             </div>
             <div className='header__menu-right is-logout'>
                 <div className='header__btn'>


### PR DESCRIPTION
This pull request introduces updates to the header styling and layout in both SCSS and JSX files. The changes aim to improve the header's visual spacing, alignment, and functionality, including adjustments to margins, padding, and the order of menu items.

### Styling adjustments in `src/sass/_common/header.scss`:

* Reduced `margin-left` from `8px` to `4px` for elements within the header to improve alignment.
* Increased `padding` for menu links from `0 8px` to `0 16px` and added specific padding for `.url-appstore`.
* Added `margin: 0 8px` to the `&__expand` class for better spacing consistency.
* Changed `margin-right: 10px` to `margin: 0 10px` for the `&__notification` class to standardize margin behavior.

### Layout updates in `src/templates/_common/_layout/header.jsx`:

* Removed the `mobile-hide` class from the `header-menu-links client_logged_in` div to make it visible across devices.
* Corrected text capitalization in the label for "Trader's Hub."
* Reorganized header menu items, including moving "Reports" back into the menu and adjusting the placement of the "Deposit" button.
* Restored the `Notification` component and the "Account Details" link in the header's menu-right section.